### PR TITLE
Fix project url and feature request link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ CodeHub is the best way to browse and maintain your GitHub repositories on any i
 
 Follow the project on twitter: [@CodeHubApp](http://www.twitter.com/CodeHubApp)<br />
 Feature requests can be made on [GitHub](https://github.com/CodeHubApp/CodeHub/issues)<br />
-Additional information can be found on the [project's webpage](http://codehub-app.com//)
+Additional information can be found on the [project's webpage](http://codehub-app.com/)
 
 ## Screenshots
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 CodeHub is the best way to browse and maintain your GitHub repositories on any iPhone, iPod Touch, and iPad device! Keep an eye on your projects with the ability to view everything from pull requests to commenting on individual file diffs in the latest change set. CodeHub brings GitHub to your finger tips in a sleek and efficient design. 
 
 Follow the project on twitter: [@CodeHubApp](http://www.twitter.com/CodeHubApp)<br />
-Feature requests can be made on [GitHub](https://github.com/thedillonb/CodeHub/issues)<br />
-Additional information can be found on the [project's webpage](http://thedillonb.github.io/CodeHub/)
+Feature requests can be made on [GitHub](https://github.com/CodeHubApp/CodeHub/issues)<br />
+Additional information can be found on the [project's webpage](http://codehub-app.com//)
 
 ## Screenshots
 


### PR DESCRIPTION
The project website url doesn't even work, so that was fixed.
The Feature Request link worked, but it's easier to cut out the middle man and just redirect to issues in the right org.