### PR TITLE
Change Link on CodeHub Banner Image. Closes #547.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="http://thedillonb.github.io/CodeHub/"><img alt="CodeHub" src="https://raw.githubusercontent.com/thedillonb/CodeHub/gh-pages/assets/CodeHubTitle.jpg" width="100%"></a>
+<a href="http://codehub-app.com/"><img alt="CodeHub" src="https://raw.githubusercontent.com/thedillonb/CodeHub/gh-pages/assets/CodeHubTitle.jpg" width="100%"></a>
 
 [![Gitter](https://badges.gitter.im/thedillonb/CodeHub.svg)](https://gitter.im/thedillonb/CodeHub?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 


### PR DESCRIPTION
This was the link causing a 404. Hope I've fixed it with the right URL.